### PR TITLE
refactor: use object freeze to create enum

### DIFF
--- a/src/constants/permissionLevels.ts
+++ b/src/constants/permissionLevels.ts
@@ -1,9 +1,9 @@
-export const PermissionLevel = {
+export const PermissionLevelValues = {
   Read: 'read',
   Write: 'write',
   Admin: 'admin',
 };
-Object.freeze(PermissionLevel);
+export const PermissionLevel = Object.freeze(PermissionLevelValues);
 type PermissionLevel = typeof PermissionLevel[keyof typeof PermissionLevel];
 
 export class PermissionLevelCompare {

--- a/src/constants/permissionLevels.ts
+++ b/src/constants/permissionLevels.ts
@@ -1,8 +1,10 @@
-export const enum PermissionLevel {
-  Read = 'read',
-  Write = 'write',
-  Admin = 'admin',
-}
+export const PermissionLevel = {
+  Read: 'read',
+  Write: 'write',
+  Admin: 'admin',
+};
+Object.freeze(PermissionLevel);
+type PermissionLevel = typeof PermissionLevel[keyof typeof PermissionLevel];
 
 export class PermissionLevelCompare {
   /**


### PR DESCRIPTION
This is a very quick fix. 
It might be possible to change `graasp-types`'s PermissionLevel and use this other repo instead, but I think it's safer to do it here for now. 

The difference between utils and types is really thin, we should think about some strategy sometime.

close #8 